### PR TITLE
调整注册先后顺序

### DIFF
--- a/src/designer/layout/index.js
+++ b/src/designer/layout/index.js
@@ -1,2 +1,2 @@
-require('./ColumnLayoutFactory')
 require('./LinearLayoutFactory')
+require('./ColumnLayoutFactory')


### PR DESCRIPTION
两个有依赖，注册先后循序不对，LinearLayoutFactory必须在ColumnLayoutFactory前面